### PR TITLE
[1.2.1] - September 19, 2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to the SpotifyPlugin for InfoPanel are documented here.
 
+## [1.2.0] - September 19, 2025
+### Added
+- **Keep song information when paused**: Track name, artist, and album are now preserved when playback is paused instead of showing "Paused"
+- **Custom messages via INI configuration**: Added two new configuration options for customizing display messages:
+  - `NoTrackMessage`: Custom message when no track is loaded in Spotify (default: "No music playing")
+  - `PausedMessage`: Custom message when track is paused (empty = keep track info, or set custom message like "⏸ Paused")
+
+### Changed
+- Enhanced `PlaybackInfo` record with `HasTrack` field to distinguish between paused tracks vs. no track loaded
+- Updated `SpotifyPlaybackService` to preserve actual track information during pause states
+- Modified UI update logic in `OnPlaybackUpdated()` to handle different playback states appropriately
+- Improved configuration file handling to include new message settings with backward compatibility
+
+### Technical Details
+- Added `_lastKnownTrack` tracking in `SpotifyPlaybackService` to maintain track information across state changes
+- Updated pause detection logic to preserve track metadata when `IsPlaying` is false but `HasTrack` is true
+- Enhanced INI file loading with automatic addition of missing configuration keys
+- Maintained backward compatibility - existing installations will get default values automatically
+
+### Configuration Example
+```ini
+[Spotify Plugin]
+ClientID=your-client-id-here
+MaxDisplayLength=20
+NoTrackMessage=♪ Spotify idle
+PausedMessage=
+ForceInvalidGrant=false
+```
+
 ## [1.1.1] - June 11, 2025
 ### Fixed
 - Resolved code issues in sealed classes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the SpotifyPlugin for InfoPanel are documented here.
 
+## [1.2.1] - September 19, 2025
+### Added
+- **Playback State Sensor**: New `PluginSensor` that provides real-time playback state information
+  - Value `0.0`: Not playing (no track loaded or error state)
+  - Value `1.0`: Paused (track loaded but playback paused)
+  - Value `2.0`: Playing (track actively playing)
+- **Enhanced InfoPanel Integration**: Playback state sensor is exposed to InfoPanel for automation and monitoring purposes
+
+### Technical Details
+- Added `_playbackState` sensor with ID "playback-state" and display name "Playback State"
+- Integrated state updates in `OnPlaybackUpdated()` method to reflect current playback conditions
+- Added state handling in error scenarios through `SetDefaultValues()` method
+- Sensor updates automatically every second matching the plugin's update interval
+
+### Benefits
+- Enables InfoPanel automation based on Spotify playback state
+- Provides precise state differentiation between not playing, paused, and actively playing
+- Real-time updates ensure accurate state representation for external integrations
+
 ## [1.2.0] - September 19, 2025
 ### Added
 - **Keep song information when paused**: Track name, artist, and album are now preserved when playback is paused instead of showing "Paused"

--- a/InfoPanel.Spotify/InfoPanel.Spotify.csproj
+++ b/InfoPanel.Spotify/InfoPanel.Spotify.csproj
@@ -15,7 +15,7 @@
     <DebugType Condition="'$(Configuration)' == 'Release'">none</DebugType>
     <!-- Limit satellite resources to English only -->
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <!-- Customize output path for Release builds -->
     <OutputPath Condition="'$(Configuration)' == 'Release'">bin\Release\net8.0-windows\InfoPanel.Spotify-v$(Version)\InfoPanel.Spotify</OutputPath>
     <!-- Prevent appending TargetFramework to OutputPath -->

--- a/InfoPanel.Spotify/InfoPanel.Spotify.csproj
+++ b/InfoPanel.Spotify/InfoPanel.Spotify.csproj
@@ -15,7 +15,7 @@
     <DebugType Condition="'$(Configuration)' == 'Release'">none</DebugType>
     <!-- Limit satellite resources to English only -->
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <!-- Customize output path for Release builds -->
     <OutputPath Condition="'$(Configuration)' == 'Release'">bin\Release\net8.0-windows\InfoPanel.Spotify-v$(Version)\InfoPanel.Spotify</OutputPath>
     <!-- Prevent appending TargetFramework to OutputPath -->

--- a/PluginInfo.ini
+++ b/PluginInfo.ini
@@ -2,5 +2,5 @@
 Name=InfoPanel.Spotify
 Description=InfoPanel Spotify Plugin
 Author=F3NN3X / Themely.dev
-Version=1.1.1
+Version=1.2.0
 Website=https://themely.dev

--- a/PluginInfo.ini
+++ b/PluginInfo.ini
@@ -2,5 +2,5 @@
 Name=InfoPanel.Spotify
 Description=InfoPanel Spotify Plugin
 Author=F3NN3X / Themely.dev
-Version=1.2.0
+Version=1.2.1
 Website=https://themely.dev

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Found a bug or have a feature idea? Open an [issue](https://github.com/F3NN3X/In
   MaxDisplayLength=20
   NoTrackMessage=No music playing
   PausedMessage=
+  NoTrackArtistMessage=-
   ForceInvalidGrant=false
   ```
 
@@ -165,6 +166,11 @@ Found a bug or have a feature idea? Open an [issue](https://github.com/F3NN3X/In
   - **Empty (default)**: Keep showing actual track information when paused
   - **Custom text**: Show custom message instead (e.g., `"⏸ Paused"`, `"Music paused"`)
 
+- **`NoTrackArtistMessage`** *(optional, default: "-")*: Custom message for the artist field when no track is playing or when using a custom paused message.
+  - **Default "-"**: Shows a dash in artist field
+  - **Custom text**: Show custom text in artist field (e.g., `"No artist"`, `""`, `"Idle"`)
+  - **Empty**: Leave artist field blank (may display as "0" in some cases)
+
 - **`ForceInvalidGrant`** *(debug only)*: Available only in debug builds for testing token refresh functionality.
 
 ### Configuration Examples
@@ -176,6 +182,7 @@ ClientID=abc123xyz
 MaxDisplayLength=25
 NoTrackMessage=No music playing
 PausedMessage=
+NoTrackArtistMessage=-
 ```
 
 **Custom messages**:
@@ -185,6 +192,7 @@ ClientID=abc123xyz
 MaxDisplayLength=30
 NoTrackMessage=♪ Spotify idle
 PausedMessage=⏸ Music paused
+NoTrackArtistMessage=No artist
 ```
 
 **Minimal setup**:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # SpotifyPlugin for InfoPanel
 
-A plugin for InfoPanel to display real-time Spotify track information, including track name, artist, album, cover URL, elapsed time, and remaining time.
+A plugin for InfoPanel to display real-time Spotify track information, including track name, artist, album, cover URL, elapsed time, and remaining time. Features smart pause handling that preserves track information and customizable display messages.
 
 ## Features
 - Displays current track details: title, artist, album, cover art URL, elapsed/remaining time, and progress percentage.
+- **Preserves track information when paused**: Song name, artist, and album remain visible during pause (v1.2.0+).
+- **Customizable display messages**: Configure custom messages for "no track playing" and paused states via `.ini` file (v1.2.0+).
 - Configurable title truncation via `MaxDisplayLength` in `.ini` file (default: 20 characters).
 - Robust pause, resume, and track end detection with visual indicators.
 - Optimized API usage with caching, rate limiting (180 req/min, 10 req/s), and automatic background token refresh.
@@ -13,7 +15,8 @@ A plugin for InfoPanel to display real-time Spotify track information, including
 Follow these steps to get the SpotifyPlugin working with InfoPanel:
 
 1. **Download the Plugin**:
-   - Download the latest release ZIP file (`SpotifyPlugin-vX.X.X.zip`) from the [GitHub Releases page](https://github.com/F3NN3X/InfoPanel.Spotify/releases).
+   - Download the latest release ZIP file (`SpotifyPlugin-v1.2.0.zip` or newer) from the [GitHub Releases page](https://github.com/F3NN3X/InfoPanel.Spotify/releases).
+   - **v1.2.0+** includes track preservation during pause and customizable messages.
 
 2. **Import the Plugin into InfoPanel**:
    - Open the InfoPanel app.
@@ -144,3 +147,48 @@ Found a bug or have a feature idea? Open an [issue](https://github.com/F3NN3X/In
   [Spotify Plugin]
   ClientID=<your-spotify-client-id>
   MaxDisplayLength=20
+  NoTrackMessage=No music playing
+  PausedMessage=
+  ForceInvalidGrant=false
+  ```
+
+### Configuration Options
+
+- **`ClientID`** *(required)*: Your Spotify Developer App Client ID. Get this from the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/).
+
+- **`MaxDisplayLength`** *(optional, default: 20)*: Maximum number of characters to display for track names, artist names, and album names. Longer text will be truncated with "...".
+
+- **`NoTrackMessage`** *(optional, default: "No music playing")*: Custom message displayed when no track is loaded in Spotify. 
+  - Examples: `"♪ Spotify idle"`, `"Ready to play music"`, `""`
+
+- **`PausedMessage`** *(optional, default: "")*: Custom message displayed when playback is paused.
+  - **Empty (default)**: Keep showing actual track information when paused
+  - **Custom text**: Show custom message instead (e.g., `"⏸ Paused"`, `"Music paused"`)
+
+- **`ForceInvalidGrant`** *(debug only)*: Available only in debug builds for testing token refresh functionality.
+
+### Configuration Examples
+
+**Default behavior** (keep track info when paused):
+```ini
+[Spotify Plugin]
+ClientID=abc123xyz
+MaxDisplayLength=25
+NoTrackMessage=No music playing
+PausedMessage=
+```
+
+**Custom messages**:
+```ini
+[Spotify Plugin] 
+ClientID=abc123xyz
+MaxDisplayLength=30
+NoTrackMessage=♪ Spotify idle
+PausedMessage=⏸ Music paused
+```
+
+**Minimal setup**:
+```ini
+[Spotify Plugin]
+ClientID=abc123xyz
+```


### PR DESCRIPTION
## [1.2.1] - September 19, 2025
### Added
- **Playback State Sensor**: New `PluginSensor` that provides real-time playback state information
  - Value `0.0`: Not playing (no track loaded or error state)
  - Value `1.0`: Paused (track loaded but playback paused)
  - Value `2.0`: Playing (track actively playing)
- **Enhanced InfoPanel Integration**: Playback state sensor is exposed to InfoPanel for automation and monitoring purposes

### Technical Details
- Added `_playbackState` sensor with ID "playback-state" and display name "Playback State"
- Integrated state updates in `OnPlaybackUpdated()` method to reflect current playback conditions
- Added state handling in error scenarios through `SetDefaultValues()` method
- Sensor updates automatically every second matching the plugin's update interval

### Benefits
- Enables InfoPanel automation based on Spotify playback state
- Provides precise state differentiation between not playing, paused, and actively playing
- Real-time updates ensure accurate state representation for external integrations

## [1.2.0] - September 19, 2025
### Added
- **Keep song information when paused**: Track name, artist, and album are now preserved when playback is paused instead of showing "Paused"
- **Custom messages via INI configuration**: Added two new configuration options for customizing display messages:
  - `NoTrackMessage`: Custom message when no track is loaded in Spotify (default: "No music playing")
  - `PausedMessage`: Custom message when track is paused (empty = keep track info, or set custom message like "⏸ Paused")

### Changed
- Enhanced `PlaybackInfo` record with `HasTrack` field to distinguish between paused tracks vs. no track loaded
- Updated `SpotifyPlaybackService` to preserve actual track information during pause states
- Modified UI update logic in `OnPlaybackUpdated()` to handle different playback states appropriately
- Improved configuration file handling to include new message settings with backward compatibility

### Technical Details
- Added `_lastKnownTrack` tracking in `SpotifyPlaybackService` to maintain track information across state changes
- Updated pause detection logic to preserve track metadata when `IsPlaying` is false but `HasTrack` is true
- Enhanced INI file loading with automatic addition of missing configuration keys
- Maintained backward compatibility - existing installations will get default values automatically

### Configuration Example
```ini
[Spotify Plugin]
ClientID=your-client-id-here
MaxDisplayLength=20
NoTrackMessage=♪ Spotify idle
PausedMessage=
ForceInvalidGrant=false
```
